### PR TITLE
update pom versions of gwt-maven-plugin, surfire & failsafe

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
 
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.20.1</version>
+        <version>2.22.1</version>
         <configuration>
           <excludes>
             <exclude>**/client/*.java</exclude>
@@ -131,7 +131,7 @@
          -->
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>2.20.1</version>
+        <version>2.22.1</version>
         <configuration>
           <includes>
             <include>**/*.class</include>
@@ -140,12 +140,12 @@
             org.gwtproject.typedarrays.shared.IntegrationTest
           </groups>
         </configuration>
-      </plugin>
+      </plugin>}
 
       <plugin>
         <groupId>net.ltgt.gwt.maven</groupId>
         <artifactId>gwt-maven-plugin</artifactId>
-        <version>1.0-rc-9</version>
+        <version>1.0.0</version>
         <extensions>true</extensions>
         <configuration>
           <moduleName>org.gwtproject.typedarrays.TypedArrays</moduleName>


### PR DESCRIPTION
update failsafe & surfire to 2.22.1, gwt-m-p to 1.0.0 -> now it compiles with Java 8 & 11